### PR TITLE
Fix compilation error by adding rice/stl.hpp include

### DIFF
--- a/ext/faiss/numo.hpp
+++ b/ext/faiss/numo.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <rice/rice.hpp>
+#include <rice/stl.hpp>
 #include <numo/narray.h>
 
 namespace numo {


### PR DESCRIPTION
# Fix compilation error by adding rice/stl.hpp include

## Issue

When compiling the gem with `bundle exec rake compile`, the following error occurs:

```
static assertion failed due to requirement '!std::is_same_v<std::string, std::
string>':
Please include rice/stl.hpp header for STL support
```

This happens because the Rice gem requires the `rice/stl.hpp` header to be explicitly included when working with STL types like `std::string`. The error occurs during compilation of the C++ extension when the Rice library tries to handle string conversions between Ruby and C++.

## Fix

Added the missing `#include <rice/stl.hpp>` to `ext/faiss/numo.hpp`, which provides the necessary template specializations for STL types.

The fix is minimal and non-invasive:

```cpp
#include <rice/rice.hpp>
#include <rice/stl.hpp>  // Added this line
#include <numo/narray.h>
```

## Testing

After making this change:

- The gem compiles successfully with `bundle exec rake compile`
- All tests pass with `bundle exec rake test`
- No functionality changes were required, as this was purely a build-time issue

## Technical Details

This issue likely started appearing with newer versions of the Rice gem or newer C++ compilers that enforce stricter template requirements. The Rice documentation mentions that `rice/stl.hpp` should be included when working with STL containers and strings.