### PR TITLE
CMake Support

### DIFF
--- a/ext/faiss/CMakeLists.txt
+++ b/ext/faiss/CMakeLists.txt
@@ -1,0 +1,57 @@
+cmake_minimum_required (VERSION 3.26)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# The Ruby extension is a shared library
+project("faiss_ruby" LANGUAGES C CXX)
+add_library (${CMAKE_PROJECT_NAME} SHARED)
+
+# Find Ruby
+find_package(Ruby REQUIRED)
+target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC ${Ruby_INCLUDE_DIR} ${Ruby_CONFIG_INCLUDE_DIR})
+target_link_libraries(${CMAKE_PROJECT_NAME} ${Ruby_LIBRARY})
+
+# Find FAISS
+include(CMakeFindDependencyMacro)
+find_package(faiss CONFIG REQUIRED)
+target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC ${faiss_INCLUDE_DIRS})
+target_link_libraries(${CMAKE_PROJECT_NAME} faiss)
+
+# Get narray include path and lib dir
+execute_process(COMMAND ${Ruby_EXECUTABLE} -r "numo/narray" -e "puts Gem.loaded_specs['numo-narray'].extension_dir"
+                RESULT_VARIABLE status
+                OUTPUT_VARIABLE narray_extension_dir
+                COMMAND_ERROR_IS_FATAL ANY)
+cmake_path(APPEND narray_include_dir "${narray_extension_dir}" "numo")
+target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC "narray_include_dir")
+target_link_directories(${CMAKE_PROJECT_NAME} PUBLIC "narray_include_dir")
+
+# Get Rice headers
+execute_process(COMMAND ${Ruby_EXECUTABLE} -r "rice" -e "puts Gem.loaded_specs['rice'].full_gem_path"
+                RESULT_VARIABLE status
+                OUTPUT_VARIABLE rice_dir
+                COMMAND_ERROR_IS_FATAL ANY)
+cmake_path(APPEND rice_include_dir "${rice_dir}" "include")
+target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC "rice_include_dir")
+
+# Define project properties
+set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES
+                      PREFIX ""
+                      SUFFIX ".dll"
+                      OUTPUT_NAME "faiss_ruby"
+                      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/../../lib" # Windows
+                      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/../../lib" # Not Windows
+                      )
+
+# Add source files
+target_sources(${CMAKE_PROJECT_NAME} PUBLIC
+               "faiss_ruby.def"
+               "faiss_ruby.cpp"
+               "index.cpp"
+               "index_binary.cpp"
+               "kmeans.cpp"
+               "pca_matrix.cpp"
+               "product_quantizer.cpp"
+               "utils.cpp")
+

--- a/ext/faiss/CMakePresets.json
+++ b/ext/faiss/CMakePresets.json
@@ -1,0 +1,89 @@
+﻿{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "linux-debug",
+      "displayName": "Linux Debug",
+      "description": "Target the Windows Subsystem for Linux (WSL) or a remote system.",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/out/build/${presetName}",
+      "installDir": "${sourceDir}/out/install/${presetName}",
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      },
+      "vendor": { "microsoft.com/VisualStudioRemoteSettings/CMake/2.0": { "remoteSourceRootDir": "$env{HOME}/.vs/$ms{projectDirName}" } }
+    },
+    {
+      "name": "macos-debug",
+      "displayName": "macOS Debug",
+      "description": "Target a remote macOS system.",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/out/build/${presetName}",
+      "installDir": "${sourceDir}/out/install/${presetName}",
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      },
+      "vendor": { "microsoft.com/VisualStudioRemoteSettings/CMake/1.0": { "sourceDir": "$env{HOME}/.vs/$ms{projectDirName}" } }
+    },
+    {
+      "name": "windows-base",
+      "description": "Target Windows with the Visual Studio development environment.",
+      "hidden": true,
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/out/build/${presetName}",
+      "installDir": "${sourceDir}/out/install/${presetName}",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "cl.exe",
+        "CMAKE_CXX_COMPILER": "cl.exe"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+    },
+    {
+      "name": "x64-debug",
+      "displayName": "x64 Debug",
+      "description": "Target Windows (64-bit) with the Visual Studio development environment. (Debug)",
+      "inherits": "windows-base",
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      },
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" }
+    },
+    {
+      "name": "x64-release",
+      "displayName": "x64 Release",
+      "description": "Target Windows (64-bit) with the Visual Studio development environment. (RelWithDebInfo)",
+      "inherits": "x64-debug",
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Release" }
+    },
+    {
+      "name": "x86-debug",
+      "displayName": "x86 Debug",
+      "description": "Target Windows (32-bit) with the Visual Studio development environment. (Debug)",
+      "inherits": "windows-base",
+      "architecture": {
+        "value": "x86",
+        "strategy": "external"
+      },
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Debug" }
+    },
+    {
+      "name": "x86-release",
+      "displayName": "x86 Release",
+      "description": "Target Windows (32-bit) with the Visual Studio development environment. (RelWithDebInfo)",
+      "inherits": "x86-debug",
+      "cacheVariables": { "CMAKE_BUILD_TYPE": "Release" }
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds support for building with faiss-ruby with CMake instead of extconf.rb. It also uses vcpkg on Windows to install faiss. This would also work well on Linux since faiss is not provided as a package by either Redhat derived distributions or Ubuntu dervied ones that I could see. Using vcpkg its a lot easier then figuring out how to install it yourself. Note this would also work fine on MacOS as an alternative to Brew.

This code assumes that the extension library is named faiss_ruby, which I think would be a better name than calling it "ext" like now which is pretty generic. I can provide a second PR that does that if you want.