### PR TITLE
Add remove_ids() function definition

### DIFF
--- a/ext/faiss/index.cpp
+++ b/ext/faiss/index.cpp
@@ -184,6 +184,18 @@ void init_index(Rice::Module& m) {
         return recons;
       })
     .define_method(
+      "reconstruct_batch",
+      [](faiss::Index &self, numo::Int64 keys) {
+        if (keys.ndim() != 1) {
+          throw Rice::Exception(rb_eArgError, "expected keys to be 1d array");
+        }
+        auto n = static_cast<std::size_t>(keys.shape()[0]);
+        auto d = static_cast<std::size_t>(self.d);
+        auto recons = numo::SFloat({n, d});
+        self.reconstruct_batch(n, keys.read_ptr(), recons.write_ptr());
+        return recons;
+      })
+    .define_method(
       "save",
       [](faiss::Index &self, Rice::String fname) {
         faiss::write_index(&self, fname.c_str());

--- a/ext/faiss/index.cpp
+++ b/ext/faiss/index.cpp
@@ -175,6 +175,15 @@ void init_index(Rice::Module& m) {
         return recons;
       })
     .define_method(
+      "reconstruct_n",
+      [](faiss::Index &self, int64_t i0, int64_t ni) {
+        auto d = static_cast<std::size_t>(self.d);
+        auto n = static_cast<std::size_t>(ni);
+        auto recons = numo::SFloat({n, d});
+        self.reconstruct_n(i0, ni, recons.write_ptr());
+        return recons;
+      })
+    .define_method(
       "save",
       [](faiss::Index &self, Rice::String fname) {
         faiss::write_index(&self, fname.c_str());

--- a/ext/faiss/index.cpp
+++ b/ext/faiss/index.cpp
@@ -241,4 +241,7 @@ void init_index(Rice::Module& m) {
 
   Rice::define_class_under<faiss::IndexIDMap, faiss::Index>(m, "IndexIDMap")
     .define_constructor(Rice::Constructor<faiss::IndexIDMap, faiss::Index*>());
+  
+  Rice::define_class_under<faiss::IndexIDMap2, faiss::Index>(m, "IndexIDMap2")
+    .define_constructor(Rice::Constructor<faiss::IndexIDMap2, faiss::Index*>());
 }

--- a/ext/faiss/index.cpp
+++ b/ext/faiss/index.cpp
@@ -177,6 +177,9 @@ void init_index(Rice::Module& m) {
     .define_method(
       "reconstruct_n",
       [](faiss::Index &self, int64_t i0, int64_t ni) {
+        if ( ni < 0) {
+          throw Rice::Exception(rb_eArgError, "expected n to be positive");
+        }
         auto d = static_cast<std::size_t>(self.d);
         auto n = static_cast<std::size_t>(ni);
         auto recons = numo::SFloat({n, d});
@@ -185,14 +188,14 @@ void init_index(Rice::Module& m) {
       })
     .define_method(
       "reconstruct_batch",
-      [](faiss::Index &self, numo::Int64 keys) {
-        if (keys.ndim() != 1) {
-          throw Rice::Exception(rb_eArgError, "expected keys to be 1d array");
+      [](faiss::Index &self, numo::Int64 ids) {
+        if (ids.ndim() != 1) {
+          throw Rice::Exception(rb_eArgError, "expected ids to be 1d array");
         }
-        auto n = static_cast<std::size_t>(keys.shape()[0]);
+        auto n = static_cast<std::size_t>(ids.shape()[0]);
         auto d = static_cast<std::size_t>(self.d);
         auto recons = numo::SFloat({n, d});
-        self.reconstruct_batch(n, keys.read_ptr(), recons.write_ptr());
+        self.reconstruct_batch(n, ids.read_ptr(), recons.write_ptr());
         return recons;
       })
     .define_method(

--- a/test/index_test.rb
+++ b/test/index_test.rb
@@ -243,6 +243,36 @@ class IndexTest < Minitest::Test
     assert_equal [[100, 102, 101], [101, 102, 100], [102, 100, 101]], ids.to_a
   end
 
+  def test_add_with_ids_id_map2
+    objects = [
+      [1, 1, 2, 1],
+      [5, 4, 6, 5],
+      [1, 2, 1, 2]
+    ]
+    ids = [100, 101, 102]
+    index = Faiss::IndexFlatL2.new(4)
+    index2 = Faiss::IndexIDMap2.new(index)
+    index2.add_with_ids(objects, ids)
+    distances, ids = index2.search(objects, 3)
+    assert_equal [[0, 3, 57], [0, 54, 57], [0, 3, 54]], distances.to_a
+    assert_equal [[100, 102, 101], [101, 102, 100], [102, 100, 101]], ids.to_a
+  end
+
+  def test_reconstruct_id_map2
+    objects = [
+      [1, 1, 2, 1],
+      [5, 4, 6, 5],
+      [1, 2, 1, 2]
+    ]
+    ids = [100, 101, 102]
+    index = Faiss::IndexFlatL2.new(4)
+    index2 = Faiss::IndexIDMap2.new(index)
+    index2.add_with_ids(objects, ids)
+    assert_equal [1, 1, 2, 1], index2.reconstruct(100).to_a
+    assert_equal [5, 4, 6, 5], index2.reconstruct(101).to_a
+    assert_equal [1, 2, 1, 2], index2.reconstruct(102).to_a
+  end
+
   def test_add_with_ids_ivf_flat
     objects = [
       [1, 1, 2, 1],

--- a/test/index_test.rb
+++ b/test/index_test.rb
@@ -349,6 +349,33 @@ class IndexTest < Minitest::Test
     end
   end
 
+  def test_reconstruct_n
+    objects = Numo::SFloat.cast([
+      [1, 1, 2, 1],
+      [5, 4, 6, 5],
+      [1, 2, 1, 2],
+      [3, 3, 3, 3],
+      [7, 8, 9, 10]
+    ])
+    index = Faiss::IndexFlatL2.new(4)
+    index.add(objects)
+
+    # Reconstruct all vectors
+    recons = index.reconstruct_n(0, 5)
+    assert_equal [5, 4], recons.shape
+    assert_equal objects.to_a, recons.to_a
+
+    # Reconstruct subset from middle
+    recons = index.reconstruct_n(1, 3)
+    assert_equal [3, 4], recons.shape
+    assert_equal objects[1..3, true].to_a, recons.to_a
+
+    # Reconstruct single vector
+    recons = index.reconstruct_n(2, 1)
+    assert_equal [1, 4], recons.shape
+    assert_equal [objects[2, true].to_a], recons.to_a
+  end
+
   def test_remove_ids
     objects = [
       [1, 1, 2, 1],

--- a/test/index_test.rb
+++ b/test/index_test.rb
@@ -319,6 +319,18 @@ class IndexTest < Minitest::Test
     end
   end
 
+  def test_remove_ids
+    objects = [
+      [1, 1, 2, 1],
+      [5, 4, 6, 5],
+      [1, 2, 1, 2]
+    ]
+    index = Faiss::IndexFlatL2.new(4)
+    index.add(objects)
+    index.remove_ids([0, 2])
+    assert_equal 1, index.ntotal
+  end
+
   private
 
   def max_float # single-precision


### PR DESCRIPTION
This adds definition for `Faiss::IndexIdMap2` and some missing Index methods